### PR TITLE
Upgrade all Jackson components to latest 2.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,11 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.22.1</version>
+      			<groupId>com.fasterxml.jackson</groupId>
+      			<artifactId>jackson-bom</artifactId>
+      			<version>2.22.1</version>
+      			<scope>import</scope>
+      			<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jersey</groupId>


### PR DESCRIPTION
(was: only the direct dependency, jackson-core, was updated). This should fix security issues in other, transitive, Jackson dependencies.